### PR TITLE
Addressed a bug in the Component#getChild methods that was causing them to return an incorrect Component

### DIFF
--- a/abyss/src/main/java/abyss/plugin/api/Component.java
+++ b/abyss/src/main/java/abyss/plugin/api/Component.java
@@ -96,7 +96,7 @@ public class Component {
     public Component getChild(Predicate<Component> filter, int... indices) {
         Component w = this;
         for (int i = 0; i < indices.length && w != null && filter.test(w); i++) {
-            w = getChild(indices[i]);
+            w = w.getChild(indices[i]);
         }
         return w;
     }
@@ -107,7 +107,7 @@ public class Component {
     public Component getChild(int... indices) {
         Component w = this;
         for (int i = 0; i < indices.length && w != null; i++) {
-            w = getChild(indices[i]);
+            w = w.getChild(indices[i]);
         }
         return w;
     }


### PR DESCRIPTION
Addressed a bug in the Component#getChild methods that was causing them to return an incorrect Component