### PR TITLE
Fix Npc.interact(string) predicate

### DIFF
--- a/abyss/src/main/java/abyss/plugin/api/Npc.java
+++ b/abyss/src/main/java/abyss/plugin/api/Npc.java
@@ -90,7 +90,7 @@ public final class Npc extends PathingEntity {
     }
 
     public boolean interact(String option) {
-        return interact(option, (o1, o2) -> o2.contains(o1));
+        return interact(option, (o1, o2) -> o2 !=null && o2.contains(o1));
     }
 
     /**


### PR DESCRIPTION
Adds a null check to prevent stack traces when iterating over a null Npc option.